### PR TITLE
feat: Create COMTRADE analysis library and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,95 @@
-# cuddly-tribble
+# COMTRADE Analysis Tool
 
+This project is a Python-based library and command-line tool for analyzing Common Format for Transient Data Exchange (COMTRADE) files. It helps electrical engineers identify conformance errors and electrical fault patterns in power system disturbance data.
 
+## Features
 
-Run the application using the following command:
+- **Conformance Checking:** Validates COMTRADE files for common formatting errors.
+- **Fault Analysis:** Detects electrical patterns like voltage sags, relay trips, and CT saturation.
+- **Library and CLI:** Can be used as a standalone command-line tool or as a library integrated into other Python applications.
+
+## Installation
+
+To use this tool, you need Python 3.12+ and `uv`.
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd cuddly-tribble
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    uv pip install -e .
+    ```
+
+## Usage
+
+### As a Command-Line Tool
+
+The CLI provides two main commands: `conformance` and `faults`.
+
+#### Conformance Analysis
+
+Checks for file format issues.
 
 ```bash
-uv run main.py
+uv run main.py conformance /path/to/your/file.cfg
 ```
 
-Run tests using the following command:
+**Example:**
+```bash
+uv run main.py conformance comtrade_files/sample_1999_bin.cfg
+```
 
+#### Fault Pattern Analysis
+
+Analyzes the waveform data to find electrical fault patterns.
+
+```bash
+uv run main.py faults /path/to/your/file.cfg --voltage-ch <ID> --current-ch <ID> --trip-ch <ID> --nominal-v <voltage>
+```
+
+**Arguments:**
+
+-   `--voltage-ch`: The channel ID for voltage analysis (e.g., `VA`).
+-   `--current-ch`: The channel ID for current analysis (e.g., `IA`).
+-   `--trip-ch`: The channel ID for the relay trip signal (e.g., `TRIP`).
+-   `--nominal-v`: The nominal voltage of the system.
+
+**Example:**
+```bash
+uv run main.py faults comtrade_files/sample_1999_bin.cfg --voltage-ch VA --current-ch IA --trip-ch TRIP --nominal-v 230
+```
+
+### As a Library
+
+You can integrate the `ComtradeAnalyzer` class into your own Python scripts.
+
+```python
+from comtrade_analyzer.analyzer import ComtradeAnalyzer
+
+# Initialize the analyzer
+analyzer = ComtradeAnalyzer("comtrade_files/sample_1999_bin.cfg")
+
+# Perform conformance checks
+conformance_errors = analyzer.check_channel_counts()
+conformance_errors.extend(analyzer.check_file_type())
+print(f"Conformance Errors: {conformance_errors}")
+
+# Detect voltage sags
+sags = analyzer.detect_voltage_sags("VA", nominal_voltage=230)
+print(f"Voltage Sags: {sags}")
+
+# Check relay operation if a sag is detected
+if sags:
+    trip_info = analyzer.check_relay_operation("TRIP", sags[0]['start_time'])
+    print(f"Trip Info: {trip_info}")
+```
+
+## Running Tests
+
+To run the test suite, use the following command:
 ```bash
 uv run pytest
 ```

--- a/comtrade_analyzer/__init__.py
+++ b/comtrade_analyzer/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the comtrade_analyzer directory a Python package.

--- a/comtrade_analyzer/analyzer.py
+++ b/comtrade_analyzer/analyzer.py
@@ -1,0 +1,195 @@
+import comtrade
+import numpy as np
+
+class ComtradeAnalyzer:
+    """
+    A class to analyze COMTRADE files for conformance errors and fault patterns.
+    """
+    def __init__(self, cfg_path: str):
+        """
+        Initializes the ComtradeAnalyzer with a path to the .cfg file.
+
+        :param cfg_path: The path to the COMTRADE .cfg file.
+        """
+        self.cfg_path = cfg_path
+        self.dat_path = cfg_path.replace('.cfg', '.dat').replace('.CFG', '.DAT')
+        self.recorder = comtrade.load(self.cfg_path, self.dat_path)
+
+    @property
+    def cfg(self):
+        """
+        Returns the CFG data of the COMTRADE file.
+        """
+        return self.recorder.cfg
+
+    @property
+    def analog_channels(self):
+        """
+        Returns the analog channels' data.
+        """
+        return self.recorder.analog
+
+    @property
+    def status_channels(self):
+        """
+        Returns the status channels' data.
+        """
+        return self.recorder.status
+
+    @property
+    def time(self):
+        """
+        Returns the time vector of the COMTRADE recording.
+        """
+        return self.recorder.time
+
+    @property
+    def trigger_time(self):
+        """
+        Returns the trigger time of the COMTRADE recording.
+        """
+        return self.recorder.trigger_time
+
+    def check_channel_counts(self) -> list:
+        """
+        Checks if the total number of channels in the CFG file matches the sum
+        of analog and digital channels.
+
+        :return: A list of error messages. An empty list means no errors.
+        """
+        errors = []
+        expected_total = self.cfg.analog_count + self.cfg.status_count
+        if self.cfg.channels_count != expected_total:
+            error_msg = (
+                f"Error: Mismatched channel counts. "
+                f"Total in CFG: {self.cfg.channels_count}, "
+                f"Sum of analog and status: {expected_total}"
+            )
+            errors.append(error_msg)
+        return errors
+
+    def check_file_type(self) -> list:
+        """
+        Checks if the file type in the CFG is valid.
+
+        :return: A list of error messages.
+        """
+        errors = []
+        if self.cfg.ft not in ['ASCII', 'BINARY']:
+            errors.append(f"Error: Invalid file type '{self.cfg.ft}'")
+        return errors
+
+    def check_for_missing_information(self, expected_freq: float = 60.0) -> list:
+        """
+        Checks for missing or invalid metadata, like line frequency.
+
+        :param expected_freq: The expected line frequency (e.g., 50.0 or 60.0).
+        :return: A list of warning or error messages.
+        """
+        warnings = []
+        if self.cfg.frequency == 0.0 or abs(self.cfg.frequency - expected_freq) > 1.0:
+            warnings.append(
+                f"Warning: Unexpected frequency detected ({self.cfg.frequency} Hz)."
+            )
+        return warnings
+
+    def _find_channel_index(self, channel_id: str, channel_type: str = "analog") -> int | None:
+        """
+        Finds the index of a channel by its ID, case-insensitively.
+
+        :param channel_id: The ID of the channel to find.
+        :param channel_type: The type of channel ('analog' or 'status').
+        :return: The index of the channel, or None if not found.
+        """
+        channel_list = self.recorder.analog_channel_ids if channel_type == "analog" else self.recorder.status_channel_ids
+        for i, ch_id in enumerate(channel_list):
+            if ch_id.strip().lower() == channel_id.lower():
+                return i
+        return None
+
+    def detect_voltage_sags(
+        self,
+        voltage_channel_id: str,
+        nominal_voltage: float,
+        threshold: float = 0.8,
+        window_size: int = 50,
+    ) -> list:
+        """
+        Detects voltage sags in a specific analog channel.
+
+        :param voltage_channel_id: The ID of the voltage channel to analyze.
+        :param nominal_voltage: The nominal voltage value for calculating the sag threshold.
+        :param threshold: The sag threshold (e.g., 0.8 for 80% of nominal voltage).
+        :param window_size: The size of the rolling window for RMS calculation.
+        :return: A list of dictionaries, each representing a detected sag event.
+        """
+        sags = []
+        voltage_index = self._find_channel_index(voltage_channel_id, "analog")
+
+        if voltage_index is None:
+            return [{"error": f"Voltage channel '{voltage_channel_id}' not found."}]
+
+        voltage_data = self.analog_channels[voltage_index]
+        rms_values = np.sqrt(
+            np.convolve(np.array(voltage_data)**2, np.ones(window_size) / window_size, mode="valid")
+        )
+        sag_threshold = nominal_voltage * threshold
+
+        sag_indices = np.where(rms_values < sag_threshold)[0]
+        if sag_indices.size > 0:
+            start_index = sag_indices[0]
+            start_time = self.time[start_index]
+            sags.append(
+                {
+                    "channel_id": voltage_channel_id,
+                    "start_time": start_time,
+                    "min_rms_voltage": rms_values[start_index],
+                }
+            )
+        return sags
+
+    def check_relay_operation(self, trip_channel_id: str, fault_start_time: float) -> dict:
+        """
+        Checks for a relay trip signal after a fault has occurred.
+
+        :param trip_channel_id: The ID of the status trip channel.
+        :param fault_start_time: The time when the fault started.
+        :return: A dictionary with the trip time and delay, or a warning if no trip is found.
+        """
+        trip_index = self._find_channel_index(trip_channel_id, "status")
+
+        if trip_index is None:
+            return {"warning": f"Trip channel '{trip_channel_id}' not found."}
+
+        trip_data = self.status_channels[trip_index]
+        trip_times = [self.time[i] for i, val in enumerate(trip_data) if val == 1]
+
+        if trip_times and trip_times[0] > fault_start_time:
+            trip_time = trip_times[0]
+            trip_delay = trip_time - fault_start_time
+            return {
+                "trip_time": trip_time,
+                "trip_delay_ms": trip_delay * 1000,
+            }
+        else:
+            return {"warning": "No trip signal detected after the fault."}
+
+    def detect_ct_saturation(self, current_channel_id: str, saturation_window: int = 5) -> dict | None:
+        """
+        Detects potential CT saturation by looking for flattened waveforms.
+
+        :param current_channel_id: The ID of the current channel to analyze.
+        :param saturation_window: The number of consecutive identical samples to consider as saturation.
+        :return: A dictionary with the saturation start time, or None if no saturation is detected.
+        """
+        current_index = self._find_channel_index(current_channel_id, "analog")
+
+        if current_index is None:
+            return {"warning": f"Current channel '{current_channel_id}' not found."}
+
+        current_data = self.analog_channels[current_index]
+        for i in range(len(current_data) - saturation_window):
+            window = current_data[i : i + saturation_window]
+            if np.all(window == window[0]):
+                return {"saturation_start_time": self.time[i]}
+        return None

--- a/comtrade_analyzer/cli.py
+++ b/comtrade_analyzer/cli.py
@@ -1,0 +1,93 @@
+import argparse
+from comtrade_analyzer.analyzer import ComtradeAnalyzer
+
+def main():
+    """
+    The main entry point for the command-line interface.
+    """
+    parser = argparse.ArgumentParser(
+        description="A tool for analyzing COMTRADE files for erroneous patterns."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Subparser for conformance analysis
+    parser_conformance = subparsers.add_parser(
+        "conformance", help="Check for conformance errors in the COMTRADE file."
+    )
+    parser_conformance.add_argument("cfg_file", help="Path to the COMTRADE .cfg file.")
+    parser_conformance.add_argument(
+        "--freq", type=float, default=60.0, help="Expected line frequency."
+    )
+
+    # Subparser for fault analysis
+    parser_faults = subparsers.add_parser(
+        "faults", help="Analyze electrical fault patterns."
+    )
+    parser_faults.add_argument("cfg_file", help="Path to the COMTRADE .cfg file.")
+    parser_faults.add_argument(
+        "--voltage-ch", required=True, help="ID of the voltage channel to analyze."
+    )
+    parser_faults.add_argument(
+        "--current-ch", required=True, help="ID of the current channel for saturation detection."
+    )
+    parser_faults.add_argument(
+        "--trip-ch", required=True, help="ID of the digital trip channel."
+    )
+    parser_faults.add_argument(
+        "--nominal-v", type=float, required=True, help="Nominal voltage."
+    )
+
+    args = parser.parse_args()
+    analyzer = ComtradeAnalyzer(args.cfg_file)
+
+    if args.command == "conformance":
+        run_conformance_checks(analyzer, args)
+    elif args.command == "faults":
+        run_fault_analysis(analyzer, args)
+
+def run_conformance_checks(analyzer: ComtradeAnalyzer, args):
+    """
+    Runs and prints the results of conformance checks.
+    """
+    print("Running conformance checks...")
+    errors = analyzer.check_channel_counts()
+    errors.extend(analyzer.check_file_type())
+    warnings = analyzer.check_for_missing_information(expected_freq=args.freq)
+
+    if not errors and not warnings:
+        print("No conformance issues found.")
+    else:
+        for error in errors:
+            print(error)
+        for warning in warnings:
+            print(warning)
+
+def run_fault_analysis(analyzer: ComtradeAnalyzer, args):
+    """
+    Runs and prints the results of fault analysis.
+    """
+    print("Running fault analysis...")
+    sags = analyzer.detect_voltage_sags(args.voltage_ch, args.nominal_v)
+    if sags:
+        sag = sags[0]
+        if "error" in sag:
+            print(f"Error detecting voltage sags: {sag['error']}")
+            return
+
+        print(f"Voltage sag detected on '{sag['channel_id']}' at {sag['start_time']:.4f}s.")
+
+        trip_info = analyzer.check_relay_operation(args.trip_ch, sag['start_time'])
+        if "warning" in trip_info:
+            print(f"Relay operation check: {trip_info['warning']}")
+        else:
+            print(f"Relay trip detected at {trip_info['trip_time']:.4f}s (Delay: {trip_info['trip_delay_ms']:.2f}ms).")
+    else:
+        print("No voltage sags detected.")
+
+    saturation_info = analyzer.detect_ct_saturation(args.current_ch)
+    if saturation_info and "warning" not in saturation_info:
+        print(f"Potential CT saturation detected on '{args.current_ch}' at {saturation_info['saturation_start_time']:.4f}s.")
+    elif saturation_info and "warning" in saturation_info:
+        print(f"CT saturation check: {saturation_info['warning']}")
+    else:
+        print("No CT saturation detected.")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
-def main():
-    print("Hello from cuddly-tribble!")
-
+from comtrade_analyzer.cli import main
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,15 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "comtrade>=0.1.2",
+    "numpy>=1.26.0",
 ]
 
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
 ]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,55 @@
+import pytest
+from comtrade_analyzer.analyzer import ComtradeAnalyzer
+
+@pytest.fixture
+def analyzer():
+    """
+    Pytest fixture to create a ComtradeAnalyzer instance for testing.
+    """
+    return ComtradeAnalyzer("comtrade_files/sample_1999_bin.cfg")
+
+def test_check_channel_counts(analyzer):
+    """
+    Tests the check_channel_counts method.
+    """
+    errors = analyzer.check_channel_counts()
+    assert not errors
+
+def test_check_file_type(analyzer):
+    """
+    Tests the check_file_type method.
+    """
+    errors = analyzer.check_file_type()
+    assert not errors
+
+def test_check_for_missing_information(analyzer):
+    """
+    Tests the check_for_missing_information method.
+    """
+    warnings = analyzer.check_for_missing_information()
+    assert not warnings
+
+def test_detect_voltage_sags(analyzer):
+    """
+    Tests the detect_voltage_sags method.
+    """
+    # This is a placeholder test. The sample file may not have a sag.
+    # In a real scenario, we would use a file with a known sag.
+    sags = analyzer.detect_voltage_sags("VA", nominal_voltage=230)
+    assert isinstance(sags, list)
+
+def test_check_relay_operation(analyzer):
+    """
+    Tests the check_relay_operation method.
+    """
+    # This is a placeholder test.
+    trip_info = analyzer.check_relay_operation("TRIP", fault_start_time=0.1)
+    assert "warning" in trip_info or "trip_time" in trip_info
+
+def test_detect_ct_saturation(analyzer):
+    """
+    Tests the detect_ct_saturation method.
+    """
+    # This is a placeholder test.
+    saturation_info = analyzer.detect_ct_saturation("IA")
+    assert saturation_info is None or "warning" in saturation_info or "saturation_start_time" in saturation_info

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -26,6 +26,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "comtrade" },
+    { name = "numpy" },
 ]
 
 [package.dev-dependencies]
@@ -34,7 +35,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "comtrade", specifier = ">=0.1.2" }]
+requires-dist = [
+    { name = "comtrade", specifier = ">=0.1.2" },
+    { name = "numpy", specifier = ">=1.26.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.4.2" }]
@@ -46,6 +50,69 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz", hash = "sha256:ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029", size = 20576648, upload-time = "2025-09-09T16:54:12.543Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/5d/bb7fc075b762c96329147799e1bcc9176ab07ca6375ea976c475482ad5b3/numpy-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cfdd09f9c84a1a934cde1eec2267f0a43a7cd44b2cca4ff95b7c0d14d144b0bf", size = 20957014, upload-time = "2025-09-09T15:56:29.966Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/0e/c6211bb92af26517acd52125a237a92afe9c3124c6a68d3b9f81b62a0568/numpy-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb32e3cf0f762aee47ad1ddc6672988f7f27045b0783c887190545baba73aa25", size = 14185220, upload-time = "2025-09-09T15:56:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f2/07bb754eb2ede9073f4054f7c0286b0d9d2e23982e090a80d478b26d35ca/numpy-2.3.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:396b254daeb0a57b1fe0ecb5e3cff6fa79a380fa97c8f7781a6d08cd429418fe", size = 5113918, upload-time = "2025-09-09T15:56:34.175Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0a/afa51697e9fb74642f231ea36aca80fa17c8fb89f7a82abd5174023c3960/numpy-2.3.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:067e3d7159a5d8f8a0b46ee11148fc35ca9b21f61e3c49fbd0a027450e65a33b", size = 6647922, upload-time = "2025-09-09T15:56:36.149Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f5/122d9cdb3f51c520d150fef6e87df9279e33d19a9611a87c0d2cf78a89f4/numpy-2.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c02d0629d25d426585fb2e45a66154081b9fa677bc92a881ff1d216bc9919a8", size = 14281991, upload-time = "2025-09-09T15:56:40.548Z" },
+    { url = "https://files.pythonhosted.org/packages/51/64/7de3c91e821a2debf77c92962ea3fe6ac2bc45d0778c1cbe15d4fce2fd94/numpy-2.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9192da52b9745f7f0766531dcfa978b7763916f158bb63bdb8a1eca0068ab20", size = 16641643, upload-time = "2025-09-09T15:56:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e4/961a5fa681502cd0d68907818b69f67542695b74e3ceaa513918103b7e80/numpy-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cd7de500a5b66319db419dc3c345244404a164beae0d0937283b907d8152e6ea", size = 16056787, upload-time = "2025-09-09T15:56:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/99/26/92c912b966e47fbbdf2ad556cb17e3a3088e2e1292b9833be1dfa5361a1a/numpy-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:93d4962d8f82af58f0b2eb85daaf1b3ca23fe0a85d0be8f1f2b7bb46034e56d7", size = 18579598, upload-time = "2025-09-09T15:56:49.844Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b6/fc8f82cb3520768718834f310c37d96380d9dc61bfdaf05fe5c0b7653e01/numpy-2.3.3-cp312-cp312-win32.whl", hash = "sha256:5534ed6b92f9b7dca6c0a19d6df12d41c68b991cef051d108f6dbff3babc4ebf", size = 6320800, upload-time = "2025-09-09T15:56:52.499Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ee/de999f2625b80d043d6d2d628c07d0d5555a677a3cf78fdf868d409b8766/numpy-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:497d7cad08e7092dba36e3d296fe4c97708c93daf26643a1ae4b03f6294d30eb", size = 12786615, upload-time = "2025-09-09T15:56:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6e/b479032f8a43559c383acb20816644f5f91c88f633d9271ee84f3b3a996c/numpy-2.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:ca0309a18d4dfea6fc6262a66d06c26cfe4640c3926ceec90e57791a82b6eee5", size = 10195936, upload-time = "2025-09-09T15:56:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b9/984c2b1ee61a8b803bf63582b4ac4242cf76e2dbd663efeafcb620cc0ccb/numpy-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f5415fb78995644253370985342cd03572ef8620b934da27d77377a2285955bf", size = 20949588, upload-time = "2025-09-09T15:56:59.087Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e4/07970e3bed0b1384d22af1e9912527ecbeb47d3b26e9b6a3bced068b3bea/numpy-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d00de139a3324e26ed5b95870ce63be7ec7352171bc69a4cf1f157a48e3eb6b7", size = 14177802, upload-time = "2025-09-09T15:57:01.73Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c7/477a83887f9de61f1203bad89cf208b7c19cc9fef0cebef65d5a1a0619f2/numpy-2.3.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9dc13c6a5829610cc07422bc74d3ac083bd8323f14e2827d992f9e52e22cd6a6", size = 5106537, upload-time = "2025-09-09T15:57:03.765Z" },
+    { url = "https://files.pythonhosted.org/packages/52/47/93b953bd5866a6f6986344d045a207d3f1cfbad99db29f534ea9cee5108c/numpy-2.3.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d79715d95f1894771eb4e60fb23f065663b2298f7d22945d66877aadf33d00c7", size = 6640743, upload-time = "2025-09-09T15:57:07.921Z" },
+    { url = "https://files.pythonhosted.org/packages/23/83/377f84aaeb800b64c0ef4de58b08769e782edcefa4fea712910b6f0afd3c/numpy-2.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:952cfd0748514ea7c3afc729a0fc639e61655ce4c55ab9acfab14bda4f402b4c", size = 14278881, upload-time = "2025-09-09T15:57:11.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a5/bf3db6e66c4b160d6ea10b534c381a1955dfab34cb1017ea93aa33c70ed3/numpy-2.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b83648633d46f77039c29078751f80da65aa64d5622a3cd62aaef9d835b6c93", size = 16636301, upload-time = "2025-09-09T15:57:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/59/1287924242eb4fa3f9b3a2c30400f2e17eb2707020d1c5e3086fe7330717/numpy-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b001bae8cea1c7dfdb2ae2b017ed0a6f2102d7a70059df1e338e307a4c78a8ae", size = 16053645, upload-time = "2025-09-09T15:57:16.534Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/93/b3d47ed882027c35e94ac2320c37e452a549f582a5e801f2d34b56973c97/numpy-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8e9aced64054739037d42fb84c54dd38b81ee238816c948c8f3ed134665dcd86", size = 18578179, upload-time = "2025-09-09T15:57:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/487a2bccbf7cc9d4bfc5f0f197761a5ef27ba870f1e3bbb9afc4bbe3fcc2/numpy-2.3.3-cp313-cp313-win32.whl", hash = "sha256:9591e1221db3f37751e6442850429b3aabf7026d3b05542d102944ca7f00c8a8", size = 6312250, upload-time = "2025-09-09T15:57:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b5/263ebbbbcede85028f30047eab3d58028d7ebe389d6493fc95ae66c636ab/numpy-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f0dadeb302887f07431910f67a14d57209ed91130be0adea2f9793f1a4f817cf", size = 12783269, upload-time = "2025-09-09T15:57:23.034Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/67b8ca554bbeaaeb3fac2e8bce46967a5a06544c9108ec0cf5cece559b6c/numpy-2.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:3c7cf302ac6e0b76a64c4aecf1a09e51abd9b01fc7feee80f6c43e3ab1b1dbc5", size = 10195314, upload-time = "2025-09-09T15:57:25.045Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d0/0d1ddec56b162042ddfafeeb293bac672de9b0cfd688383590090963720a/numpy-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:eda59e44957d272846bb407aad19f89dc6f58fecf3504bd144f4c5cf81a7eacc", size = 21048025, upload-time = "2025-09-09T15:57:27.257Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9e/1996ca6b6d00415b6acbdd3c42f7f03ea256e2c3f158f80bd7436a8a19f3/numpy-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:823d04112bc85ef5c4fda73ba24e6096c8f869931405a80aa8b0e604510a26bc", size = 14301053, upload-time = "2025-09-09T15:57:30.077Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/43da09aa764c68694b76e84b3d3f0c44cb7c18cdc1ba80e48b0ac1d2cd39/numpy-2.3.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:40051003e03db4041aa325da2a0971ba41cf65714e65d296397cc0e32de6018b", size = 5229444, upload-time = "2025-09-09T15:57:32.733Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/14/50ffb0f22f7218ef8af28dd089f79f68289a7a05a208db9a2c5dcbe123c1/numpy-2.3.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:6ee9086235dd6ab7ae75aba5662f582a81ced49f0f1c6de4260a78d8f2d91a19", size = 6738039, upload-time = "2025-09-09T15:57:34.328Z" },
+    { url = "https://files.pythonhosted.org/packages/55/52/af46ac0795e09657d45a7f4db961917314377edecf66db0e39fa7ab5c3d3/numpy-2.3.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94fcaa68757c3e2e668ddadeaa86ab05499a70725811e582b6a9858dd472fb30", size = 14352314, upload-time = "2025-09-09T15:57:36.255Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b1/dc226b4c90eb9f07a3fff95c2f0db3268e2e54e5cce97c4ac91518aee71b/numpy-2.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da1a74b90e7483d6ce5244053399a614b1d6b7bc30a60d2f570e5071f8959d3e", size = 16701722, upload-time = "2025-09-09T15:57:38.622Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9d/9d8d358f2eb5eced14dba99f110d83b5cd9a4460895230f3b396ad19a323/numpy-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2990adf06d1ecee3b3dcbb4977dfab6e9f09807598d647f04d385d29e7a3c3d3", size = 16132755, upload-time = "2025-09-09T15:57:41.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/27/b3922660c45513f9377b3fb42240bec63f203c71416093476ec9aa0719dc/numpy-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ed635ff692483b8e3f0fcaa8e7eb8a75ee71aa6d975388224f70821421800cea", size = 18651560, upload-time = "2025-09-09T15:57:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8e/3ab61a730bdbbc201bb245a71102aa609f0008b9ed15255500a99cd7f780/numpy-2.3.3-cp313-cp313t-win32.whl", hash = "sha256:a333b4ed33d8dc2b373cc955ca57babc00cd6f9009991d9edc5ddbc1bac36bcd", size = 6442776, upload-time = "2025-09-09T15:57:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3a/e22b766b11f6030dc2decdeff5c2fb1610768055603f9f3be88b6d192fb2/numpy-2.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:4384a169c4d8f97195980815d6fcad04933a7e1ab3b530921c3fef7a1c63426d", size = 12927281, upload-time = "2025-09-09T15:57:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/42/c2e2bc48c5e9b2a83423f99733950fbefd86f165b468a3d85d52b30bf782/numpy-2.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:75370986cc0bc66f4ce5110ad35aae6d182cc4ce6433c40ad151f53690130bf1", size = 10265275, upload-time = "2025-09-09T15:57:49.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/01/342ad585ad82419b99bcf7cebe99e61da6bedb89e213c5fd71acc467faee/numpy-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cd052f1fa6a78dee696b58a914b7229ecfa41f0a6d96dc663c1220a55e137593", size = 20951527, upload-time = "2025-09-09T15:57:52.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d8/204e0d73fc1b7a9ee80ab1fe1983dd33a4d64a4e30a05364b0208e9a241a/numpy-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:414a97499480067d305fcac9716c29cf4d0d76db6ebf0bf3cbce666677f12652", size = 14186159, upload-time = "2025-09-09T15:57:54.407Z" },
+    { url = "https://files.pythonhosted.org/packages/22/af/f11c916d08f3a18fb8ba81ab72b5b74a6e42ead4c2846d270eb19845bf74/numpy-2.3.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:50a5fe69f135f88a2be9b6ca0481a68a136f6febe1916e4920e12f1a34e708a7", size = 5114624, upload-time = "2025-09-09T15:57:56.5Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/11/0ed919c8381ac9d2ffacd63fd1f0c34d27e99cab650f0eb6f110e6ae4858/numpy-2.3.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:b912f2ed2b67a129e6a601e9d93d4fa37bef67e54cac442a2f588a54afe5c67a", size = 6642627, upload-time = "2025-09-09T15:57:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/deb5f77cb0f7ba6cb52b91ed388b47f8f3c2e9930d4665c600408d9b90b9/numpy-2.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e318ee0596d76d4cb3d78535dc005fa60e5ea348cd131a51e99d0bdbe0b54fe", size = 14296926, upload-time = "2025-09-09T15:58:00.035Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cc/70e59dcb84f2b005d4f306310ff0a892518cc0c8000a33d0e6faf7ca8d80/numpy-2.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce020080e4a52426202bdb6f7691c65bb55e49f261f31a8f506c9f6bc7450421", size = 16638958, upload-time = "2025-09-09T15:58:02.738Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/5a/b2ab6c18b4257e099587d5b7f903317bd7115333ad8d4ec4874278eafa61/numpy-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e6687dc183aa55dae4a705b35f9c0f8cb178bcaa2f029b241ac5356221d5c021", size = 16071920, upload-time = "2025-09-09T15:58:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f1/8b3fdc44324a259298520dd82147ff648979bed085feeacc1250ef1656c0/numpy-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d8f3b1080782469fdc1718c4ed1d22549b5fb12af0d57d35e992158a772a37cf", size = 18577076, upload-time = "2025-09-09T15:58:07.745Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a1/b87a284fb15a42e9274e7fcea0dad259d12ddbf07c1595b26883151ca3b4/numpy-2.3.3-cp314-cp314-win32.whl", hash = "sha256:cb248499b0bc3be66ebd6578b83e5acacf1d6cb2a77f2248ce0e40fbec5a76d0", size = 6366952, upload-time = "2025-09-09T15:58:10.096Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5f/1816f4d08f3b8f66576d8433a66f8fa35a5acfb3bbd0bf6c31183b003f3d/numpy-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:691808c2b26b0f002a032c73255d0bd89751425f379f7bcd22d140db593a96e8", size = 12919322, upload-time = "2025-09-09T15:58:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/de/072420342e46a8ea41c324a555fa90fcc11637583fb8df722936aed1736d/numpy-2.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:9ad12e976ca7b10f1774b03615a2a4bab8addce37ecc77394d8e986927dc0dfe", size = 10478630, upload-time = "2025-09-09T15:58:14.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/df/ee2f1c0a9de7347f14da5dd3cd3c3b034d1b8607ccb6883d7dd5c035d631/numpy-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9cc48e09feb11e1db00b320e9d30a4151f7369afb96bd0e48d942d09da3a0d00", size = 21047987, upload-time = "2025-09-09T15:58:16.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/92/9453bdc5a4e9e69cf4358463f25e8260e2ffc126d52e10038b9077815989/numpy-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:901bf6123879b7f251d3631967fd574690734236075082078e0571977c6a8e6a", size = 14301076, upload-time = "2025-09-09T15:58:20.343Z" },
+    { url = "https://files.pythonhosted.org/packages/13/77/1447b9eb500f028bb44253105bd67534af60499588a5149a94f18f2ca917/numpy-2.3.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:7f025652034199c301049296b59fa7d52c7e625017cae4c75d8662e377bf487d", size = 5229491, upload-time = "2025-09-09T15:58:22.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f9/d72221b6ca205f9736cb4b2ce3b002f6e45cd67cd6a6d1c8af11a2f0b649/numpy-2.3.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:533ca5f6d325c80b6007d4d7fb1984c303553534191024ec6a524a4c92a5935a", size = 6737913, upload-time = "2025-09-09T15:58:24.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5f/d12834711962ad9c46af72f79bb31e73e416ee49d17f4c797f72c96b6ca5/numpy-2.3.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0edd58682a399824633b66885d699d7de982800053acf20be1eaa46d92009c54", size = 14352811, upload-time = "2025-09-09T15:58:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0d/fdbec6629d97fd1bebed56cd742884e4eead593611bbe1abc3eb40d304b2/numpy-2.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:367ad5d8fbec5d9296d18478804a530f1191e24ab4d75ab408346ae88045d25e", size = 16702689, upload-time = "2025-09-09T15:58:28.831Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/09/0a35196dc5575adde1eb97ddfbc3e1687a814f905377621d18ca9bc2b7dd/numpy-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8f6ac61a217437946a1fa48d24c47c91a0c4f725237871117dea264982128097", size = 16133855, upload-time = "2025-09-09T15:58:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ca/c9de3ea397d576f1b6753eaa906d4cdef1bf97589a6d9825a349b4729cc2/numpy-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:179a42101b845a816d464b6fe9a845dfaf308fdfc7925387195570789bb2c970", size = 18652520, upload-time = "2025-09-09T15:58:33.762Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c2/e5ed830e08cd0196351db55db82f65bc0ab05da6ef2b72a836dcf1936d2f/numpy-2.3.3-cp314-cp314t-win32.whl", hash = "sha256:1250c5d3d2562ec4174bce2e3a1523041595f9b651065e4a4473f5f48a6bc8a5", size = 6515371, upload-time = "2025-09-09T15:58:36.04Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c7/b0f6b5b67f6788a0725f744496badbb604d226bf233ba716683ebb47b570/numpy-2.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b37a0b2e5935409daebe82c1e42274d30d9dd355852529eab91dab8dcca7419f", size = 13112576, upload-time = "2025-09-09T15:58:37.927Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b9/33bba5ff6fb679aa0b1f8a07e853f002a6b04b9394db3069a1270a7784ca/numpy-2.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:78c9f6560dc7e6b3990e32df7ea1a50bbd0e2a111e05209963f5ddcab7073b0b", size = 10545953, upload-time = "2025-09-09T15:58:40.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces a new Python library and command-line tool for analyzing COMTRADE files.

The `comtrade_analyzer` library provides a `ComtradeAnalyzer` class that can be used to perform various analyses on COMTRADE files, including:
- Conformance checks for channel counts, file types, and missing information.
- Electrical fault pattern analysis for voltage sags, relay operations, and CT saturation.

The command-line interface allows users to run these analyses from the terminal using the `conformance` and `faults` subcommands.

The project includes unit tests and a comprehensive README with installation and usage instructions.