### PR TITLE
feat: Add optional encoding argument to CLI tasks

### DIFF
--- a/comtrade_analyzer/cli.py
+++ b/comtrade_analyzer/cli.py
@@ -17,6 +17,12 @@ def main():
         help="Display information about the COMTRADE file, including channel IDs.",
     )
     parser_info.add_argument("cfg_file", help="Path to the COMTRADE .cfg file.")
+    parser_info.add_argument(
+        "--encoding",
+        type=str,
+        default="utf-8",
+        help="Encoding of the configuration file.",
+    )
 
     # Subparser for conformance analysis
     parser_conformance = subparsers.add_parser(
@@ -25,6 +31,12 @@ def main():
     parser_conformance.add_argument("cfg_file", help="Path to the COMTRADE .cfg file.")
     parser_conformance.add_argument(
         "--freq", type=float, default=60.0, help="Expected line frequency."
+    )
+    parser_conformance.add_argument(
+        "--encoding",
+        type=str,
+        default="utf-8",
+        help="Encoding of the configuration file.",
     )
 
     # Subparser for fault analysis
@@ -46,6 +58,12 @@ def main():
     parser_faults.add_argument(
         "--nominal-v", type=float, required=True, help="Nominal voltage."
     )
+    parser_faults.add_argument(
+        "--encoding",
+        type=str,
+        default="utf-8",
+        help="Encoding of the configuration file.",
+    )
 
     # Subparser for fault analysis grid search
     parser_faults_gs = subparsers.add_parser(
@@ -56,17 +74,26 @@ def main():
     parser_faults_gs.add_argument(
         "--nominal-v", type=float, required=True, help="Nominal voltage."
     )
+    parser_faults_gs.add_argument(
+        "--encoding",
+        type=str,
+        default="utf-8",
+        help="Encoding of the configuration file.",
+    )
 
     args = parser.parse_args()
-    analyzer = ComtradeAnalyzer(args.cfg_file)
 
     if args.command == "info":
+        analyzer = ComtradeAnalyzer(args.cfg_file, encoding=args.encoding)
         run_info(analyzer)
     elif args.command == "conformance":
+        analyzer = ComtradeAnalyzer(args.cfg_file, encoding=args.encoding)
         run_conformance_checks(analyzer, args)
     elif args.command == "faults":
+        analyzer = ComtradeAnalyzer(args.cfg_file, encoding=args.encoding)
         run_fault_analysis(analyzer, args)
     elif args.command == "faults-grid-search":
+        analyzer = ComtradeAnalyzer(args.cfg_file, encoding=args.encoding)
         run_fault_analysis_grid_search(analyzer, args)
 
 


### PR DESCRIPTION
This commit adds an optional `--encoding` argument to the CLI tasks (`info`, `conformance`, `faults`, `faults-grid-search`) that accept a COMTRADE configuration file.

The `ComtradeAnalyzer` constructor already supported an `encoding` parameter, but it was not exposed through the command-line interface. This change makes it possible to specify the encoding for the configuration file when running the analysis tasks.

The `ComtradeAnalyzer` instantiation has been moved into the command-specific logic to make the CLI more robust and prevent potential errors if new commands are added that do not require a configuration file.